### PR TITLE
Upgraded to use Java 25 (Temurin 25 LTS). All tests pass.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,10 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.github/workflows/maven-test.yaml
+++ b/.github/workflows/maven-test.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up Java JDK
       uses: actions/setup-java@v4
       with:
         java-version: '25'

--- a/.github/workflows/maven-test.yaml
+++ b/.github/workflows/maven-test.yaml
@@ -1,0 +1,31 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ buildNumber.properties
 # Intellij
 .idea
 *.iml
+
+# VSCode
+.vscode

--- a/.project
+++ b/.project
@@ -4,16 +4,31 @@
 	<comment></comment>
 	<projects>
 	</projects>
-	<buildSpec> 
-        <buildCommand> 
-            <name>org.eclipse.jdt.core.javabuilder</name> 
-        </buildCommand> 
-        <buildCommand> 
-            <name>org.eclipse.m2e.core.maven2Builder</name> 
-        </buildCommand> 
-    </buildSpec> 
-    <natures> 
-        <nature>org.eclipse.jdt.core.javanature</nature> 
-        <nature>org.eclipse.m2e.core.maven2Nature</nature> 
-    </natures> 
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1730932987380</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -31,36 +31,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <doCheck>false</doCheck>
-                    <doUpdate>false</doUpdate>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.3.0</version>
-                  <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <D1-version>${project.version}</D1-version>
-                            <D1-SCM-Revision>${buildNumber}</D1-SCM-Revision>
-                            <D1-SCM-Branch>${scmBranch}</D1-SCM-Branch>
-                            <D1-Build-TimeStamp>${timestamp}</D1-Build-TimeStamp>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,24 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dataone</groupId>
     <artifactId>d1_portal</artifactId>
-    <version>2.3.3</version>
-    <name>d1_portal</name>
+    <version>2.5.0-SNAPSHOT</version>
+    <name>d1_portal</name>  
     <packaging>jar</packaging>
     <url>http://maven.apache.org</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.target.version>8</compiler.target.version>
+        <compiler.target.version>25</compiler.target.version>
         <d1_libclient_java.version>2.3.1</d1_libclient_java.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>net.oauth.core</groupId>
+                <artifactId>oauth-httpclient4</artifactId>
+                <version>20090913</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
@@ -18,8 +27,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>8</source>
-                    <target>${compiler.target.version}</target>
+                    <release>${compiler.target.version}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -67,7 +75,7 @@
     <repositories>
         <repository>
             <id>dataone.org</id>
-            <url>http://maven.dataone.org/</url>
+            <url>https://maven.dataone.org/</url>
             <releases>
                     <enabled>true</enabled>
             </releases>
@@ -77,16 +85,44 @@
         </repository>
     </repositories>
     <dependencies>
+<!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+            </dependency>
+        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>3.1.2</version>
+            <version>10.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.oauth.core</groupId>
+            <artifactId>oauth-httpclient4</artifactId>
+            <version>20090913</version>
+        </dependency>
+        <!-- Force Apache HttpClient/httpcore versions to match d1_libclient_java transitive deps -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.3.2</version>
         </dependency>
         <dependency>
             <groupId>edu.uiuc.ncsa.myproxy</groupId>

--- a/src/main/java/org/dataone/portal/TokenGenerator.java
+++ b/src/main/java/org/dataone/portal/TokenGenerator.java
@@ -2,7 +2,12 @@ package org.dataone.portal;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.URI;
 import java.net.URL;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -126,7 +131,7 @@ public class TokenGenerator {
         String baseUrl = "URL NOT FOUND!";
         try {
             baseUrl = D1Client.getCN().getNodeBaseServiceUrl();
-            URL url = new URL(baseUrl);
+            URL url = new URI(baseUrl).toURL();
             log.debug("Fetching server certificate from CN URL: " + url);
             HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
             conn.connect();
@@ -156,20 +161,17 @@ public class TokenGenerator {
         expires.add(Calendar.SECOND, TTL_SECONDS);
 
         // Prepare JWT with claims set
-        JWTClaimsSet claimsSet = new JWTClaimsSet();
-        // claims for annotator: http://docs.annotatorjs.org/en/v1.2.x/authentication.html
-        claimsSet.setClaim("consumerKey", consumerKey);
-        claimsSet.setClaim("userId", userId);
-        claimsSet.setClaim("issuedAt", DateTimeMarshaller.serializeDateToUTC(now.getTime()));
-        claimsSet.setClaim("ttl", TTL_SECONDS);
-
-        claimsSet.setClaim("fullName", fullName);
-
         // standard JWT fields: https://tools.ietf.org/html/rfc7519#section-4.1.4
-        claimsSet.setSubject(userId);
-        claimsSet.setIssueTime(now.getTime());
-        claimsSet.setExpirationTime(expires.getTime());
-
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            .claim("consumerKey", consumerKey)
+            .claim("userId", userId)
+            .claim("issuedAt", DateTimeMarshaller.serializeDateToUTC(now.getTime()))
+            .claim("ttl", TTL_SECONDS)
+            .claim("fullName", fullName)
+            .subject(userId)
+            .issueTime(now.getTime())
+            .expirationTime(expires.getTime())
+            .build();
         // purposefully skipping setting the claimsSet.setNotBeforeTime(nbf) to
         // avoid fussiness related to clock skew.
 


### PR DESCRIPTION
Upgraded to use Java 25 (Temurin 25 LTS). All tests pass.

Also tested with `mvn clean test` against temurin 17 and 21 which both worked fine as well. As d1_portal will be deployed standalone, it seemed prudent to move to the most recent LTS release.